### PR TITLE
#6 Feature to support multiple validation messages.

### DIFF
--- a/src/main/java/org/carlfx/cognitive/validator/BooleanConsumerValidator.java
+++ b/src/main/java/org/carlfx/cognitive/validator/BooleanConsumerValidator.java
@@ -1,0 +1,29 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright © 2024. Carl Dea.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.carlfx.cognitive.validator;
+
+import javafx.beans.property.ReadOnlyBooleanProperty;
+import org.carlfx.cognitive.viewmodel.ViewModel;
+
+/**
+ * A boolean type validator that allows a developer to add many validation messages.
+ * This is a tri-(ple) consumer taking a read-only boolean property, validation result, and view model.
+ */
+public interface BooleanConsumerValidator extends TypeConsumerValidator<ReadOnlyBooleanProperty, ValidationResult, ViewModel> {
+}

--- a/src/main/java/org/carlfx/cognitive/validator/ConsumerValidator.java
+++ b/src/main/java/org/carlfx/cognitive/validator/ConsumerValidator.java
@@ -1,0 +1,33 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright © 2024. Carl Dea.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.carlfx.cognitive.validator;
+
+import org.carlfx.cognitive.viewmodel.ViewModel;
+
+import java.util.function.BiConsumer;
+
+/** All consumer type validators don't return a validation message like simple validators, but allows
+ * the developer to add any number of validation messages.
+ *
+ * A ConsumerValidator is a bi consumer that provides the caller with an instance of a validation result
+ * and view model. A validation result allows the caller to add any number of validation messages to the
+ * validation result.
+ */
+public interface ConsumerValidator extends BiConsumer<ValidationResult, ViewModel> {
+}

--- a/src/main/java/org/carlfx/cognitive/validator/DoubleConsumerValidator.java
+++ b/src/main/java/org/carlfx/cognitive/validator/DoubleConsumerValidator.java
@@ -1,0 +1,41 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright © 2024. Carl Dea.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.carlfx.cognitive.validator;
+
+import javafx.beans.property.ReadOnlyDoubleProperty;
+import org.carlfx.cognitive.viewmodel.ViewModel;
+
+
+/**
+ * A double type validator that allows a developer to add many validation messages.
+ * This is a tri-(ple) consumer taking a read-only double property, validation result, and view model.
+ * <pre>{@code
+ * myViewModel.addProperty(MPG, 20.5d)
+ *            .addValidator(MPG, "Miles Per Gallon", (ReadOnlyFloatProperty prop, ValidationResult vr, ViewModel vm) -> {
+ *               if (prop.get() < 1.0 || prop.get() > 20) {
+ *                 vr.error("${%s} must be in range 1.0 - 20.0. Entered as %s ".formatted(MPG, prop.get()));
+ *               }
+ *               if (prop.get() % 2 != 0) {
+ *                 vr.error("${%s} must be an even number. Entered as %s ".formatted(MPG, prop.get()));
+ *               }
+ *            });
+ * }</pre>
+ */
+public interface DoubleConsumerValidator extends TypeConsumerValidator<ReadOnlyDoubleProperty, ValidationResult, ViewModel> {
+}

--- a/src/main/java/org/carlfx/cognitive/validator/FloatConsumerValidator.java
+++ b/src/main/java/org/carlfx/cognitive/validator/FloatConsumerValidator.java
@@ -1,0 +1,40 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright © 2024. Carl Dea.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.carlfx.cognitive.validator;
+
+import javafx.beans.property.ReadOnlyFloatProperty;
+import org.carlfx.cognitive.viewmodel.ViewModel;
+
+/**
+ * A float type validator that allows a developer to add many validation messages.
+ * This is a tri-(ple) consumer taking a read-only float property, validation result, and view model.
+ * <pre>{@code
+ * myViewModel.addProperty(MPG, 20.5f)
+ *            .addValidator(MPG, "Miles Per Gallon", (ReadOnlyFloatProperty prop, ValidationResult vr, ViewModel vm) -> {
+ *               if (prop.get() < 1.0 || prop.get() > 20) {
+ *                 vr.error("${%s} must be in range 1.0 - 20.0. Entered as %s ".formatted(MPG, prop.get()));
+ *               }
+ *               if (prop.get() % 2 != 0) {
+ *                 vr.error("${%s} must be an even number. Entered as %s ".formatted(MPG, prop.get()));
+ *               }
+ *            });
+ * }</pre>
+ */
+public interface FloatConsumerValidator extends TypeConsumerValidator<ReadOnlyFloatProperty, ValidationResult, ViewModel> {
+}

--- a/src/main/java/org/carlfx/cognitive/validator/IntegerConsumerValidator.java
+++ b/src/main/java/org/carlfx/cognitive/validator/IntegerConsumerValidator.java
@@ -1,0 +1,40 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright © 2024. Carl Dea.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.carlfx.cognitive.validator;
+
+import javafx.beans.property.ReadOnlyIntegerProperty;
+import org.carlfx.cognitive.viewmodel.ViewModel;
+
+/**
+ * An integer type validator that allows a developer to add many validation messages.
+ * This is a tri-(ple) consumer taking a read-only integer property, validation result, and view model.
+ * <pre>{@code
+ * myViewModel.addProperty(BRAIN_CELLS, 20)
+ *            .addValidator(BRAIN_CELLS, "Brain Cells", (ReadOnlyIntegerProperty prop, ValidationResult vr, ViewModel vm) -> {
+ *               if (prop.get() < 1 || prop.get() > 20) {
+ *                 vr.error("${%s} must be in range 1 - 20. Entered as %s ".formatted(BRAIN_CELLS, prop.get()));
+ *               }
+ *               if (prop.get() % 2 != 0) {
+ *                 vr.error("${%s} must be an even number. Entered as %s ".formatted(BRAIN_CELLS, prop.get()));
+ *               }
+ *            });
+ * }</pre>
+ */
+public interface IntegerConsumerValidator extends TypeConsumerValidator<ReadOnlyIntegerProperty, ValidationResult, ViewModel> {
+}

--- a/src/main/java/org/carlfx/cognitive/validator/ListConsumerValidator.java
+++ b/src/main/java/org/carlfx/cognitive/validator/ListConsumerValidator.java
@@ -1,0 +1,41 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright © 2024. Carl Dea.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.carlfx.cognitive.validator;
+
+import javafx.beans.property.ReadOnlyListProperty;
+import org.carlfx.cognitive.viewmodel.ViewModel;
+
+
+/**
+ * An observable list type validator that allows a developer to add many validation messages.
+ * This is a tri-(ple) consumer taking a read-only list property, validation result, and view model.
+ * <pre>{@code
+ * myViewModel.addProperty(GRADES, List.of("F", "B")
+ *            .addValidator(GRADES, "GRADES", (ReadOnlyListProperty prop, ValidationResult vr, ViewModel vm) -> {
+ *               if (prop.get().size() > 1 ) {
+ *                 vr.error("${%s} must have at least two values. Entered as %s ".formatted(GRADES, prop.get()));
+ *                 if (prop.get().get(0).equals("F")) {
+ *                     vr.error("${%s} first grade is an F (failing). Entered as %s ".formatted(GRADES, "F"));
+ *                 }
+ *               }
+ *            });
+ * }</pre>
+ */
+public interface ListConsumerValidator extends TypeConsumerValidator<ReadOnlyListProperty, ValidationResult, ViewModel> {
+}

--- a/src/main/java/org/carlfx/cognitive/validator/LongConsumerValidator.java
+++ b/src/main/java/org/carlfx/cognitive/validator/LongConsumerValidator.java
@@ -1,0 +1,40 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright © 2024. Carl Dea.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.carlfx.cognitive.validator;
+
+import javafx.beans.property.ReadOnlyLongProperty;
+import org.carlfx.cognitive.viewmodel.ViewModel;
+
+/**
+ * An long type validator that allows a developer to add many validation messages.
+ * This is a tri-(ple) consumer taking a read-only long property, validation result, and view model.
+ * <pre>{@code
+ * myViewModel.addProperty(BRAIN_CELLS, 20l)
+ *            .addValidator(BRAIN_CELLS, "Brain Cells", (ReadOnlyLongProperty prop, ValidationResult vr, ViewModel vm) -> {
+ *               if (prop.get() < 1 || prop.get() > 20l) {
+ *                 vr.error("${%s} must be in range 1 - 20. Entered as %s ".formatted(BRAIN_CELLS, prop.get()));
+ *               }
+ *               if (prop.get() % 2 != 0) {
+ *                 vr.error("${%s} must be an even number. Entered as %s ".formatted(BRAIN_CELLS, prop.get()));
+ *               }
+ *            });
+ * }</pre>
+ */
+public interface LongConsumerValidator extends TypeConsumerValidator<ReadOnlyLongProperty, ValidationResult, ViewModel> {
+}

--- a/src/main/java/org/carlfx/cognitive/validator/ObjectConsumerValidator.java
+++ b/src/main/java/org/carlfx/cognitive/validator/ObjectConsumerValidator.java
@@ -1,0 +1,38 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright © 2024. Carl Dea.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.carlfx.cognitive.validator;
+
+import javafx.beans.property.ReadOnlyObjectProperty;
+import org.carlfx.cognitive.viewmodel.ViewModel;
+
+/**
+ * An Object validator that allows a developer to add many validation messages.
+ * This is a tri-(ple) consumer taking a read-only object property, validation result, and view model.
+ * <pre>{@code
+ * myViewModel.addProperty(BRAIN, new Object())
+ *            .addValidator(BRAIN, "Brain", (ReadOnlyObjectProperty prop, ValidationResult vr, ViewModel vm) -> {
+ *               if (prop.isNull().get())
+ *                 vr.error("${%s} must be a valid instance. Entered as null ");
+ *                 vr.warn("${%s} must be a valid instance. Entered as null ");
+ *               }
+ *            });
+ * }</pre>
+ */
+public interface ObjectConsumerValidator extends TypeConsumerValidator<ReadOnlyObjectProperty, ValidationResult, ViewModel> {
+}

--- a/src/main/java/org/carlfx/cognitive/validator/SetConsumerValidator.java
+++ b/src/main/java/org/carlfx/cognitive/validator/SetConsumerValidator.java
@@ -1,0 +1,39 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright © 2024. Carl Dea.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.carlfx.cognitive.validator;
+
+import javafx.beans.property.ReadOnlySetProperty;
+import org.carlfx.cognitive.viewmodel.ViewModel;
+
+/**
+ * An observable set type validator that allows a developer to add many validation messages.
+ *
+ * <pre>{@code
+ * myViewModel.addProperty(GRADES, List.of("F", "B")
+ *            .addValidator(GRADES, "GRADES", (ReadOnlySetProperty prop, ValidationResult vr, ViewModel vm) -> {
+ *               if (prop.get().size() > 1 ) {
+ *                 vr.error("${%s} must have at least two values. Entered as %s ".formatted(GRADES, prop.get()));
+ *                 if (prop.get().filter(str -> "F".equals(str)).toList().size() > 0) {
+ *                     vr.error("${%s} any grade of F is failing. ".formatted(GRADES));
+ *                 }
+ *               }
+ *            });
+ * }</pre>
+ */
+public interface SetConsumerValidator extends TypeConsumerValidator<ReadOnlySetProperty, ValidationResult, ViewModel> {
+}

--- a/src/main/java/org/carlfx/cognitive/validator/StringConsumerValidator.java
+++ b/src/main/java/org/carlfx/cognitive/validator/StringConsumerValidator.java
@@ -1,0 +1,37 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright © 2023-2024 Carl Dea.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.carlfx.cognitive.validator;
+
+import javafx.beans.property.ReadOnlyStringProperty;
+import org.carlfx.cognitive.viewmodel.ViewModel;
+
+/**
+ * A string type validator that allows a developer to add many validation messages.
+ * This is a tri-(ple) consumer taking a read-only string property, validation result, and view model.
+ * <pre>{@code
+ * myViewModel.addProperty(FIRST_NAME, "FRED")
+ *            .addValidator(FIRST_NAME, "First Name", (ReadOnlyStringProperty prop, ValidationResult vr, ViewModel vm) -> {
+ *               if (prop.get().equals(prop.get().toLowerCase()) {
+ *                 vr.error("${%s} must be lower case. Entered as %s ".formatted(FIRST_NAME, prop.get()));
+ *                 vr.warn("${%s} must be lower case. Entered as %s ".formatted(FIRST_NAME, prop.get()));
+ *               }
+ *            });
+ * }</pre>
+ */
+public interface StringConsumerValidator extends TypeConsumerValidator<ReadOnlyStringProperty, ValidationResult, ViewModel> {
+}

--- a/src/main/java/org/carlfx/cognitive/validator/TypeConsumerValidator.java
+++ b/src/main/java/org/carlfx/cognitive/validator/TypeConsumerValidator.java
@@ -1,0 +1,58 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright © 2024. Carl Dea.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.carlfx.cognitive.validator;
+
+import java.util.Objects;
+
+/**
+ * A generic type validator that allows a developer to add many validation messages.
+ * Derived functional interfaces will extend and target a property's data value type.
+ *
+ * E.g. To validate a field of type integer the consumer validator allows the developer to add validation messages such as:
+ *       two validation messages: error message of value must be less than 100 and must be an even number.
+ *
+ * @see org.carlfx.cognitive.validator.IntegerConsumerValidator
+ *
+ * All consumer type validators don't return a validation message like simple validators. This allows
+ * the developer to add any number of validation messages. The generic type T is the JavaFX read-only property's
+ * data type.
+ *
+ *
+ * @param <T> JavaFX ReadOnly Property based on a data type such as ReadOnlyBooleanProperty, ReadOnlyIntegerProperty
+ * @param <ValidationResult> A validation result contains a list of validation messages.
+ * @param <ViewModel> The view model validating against.
+ */
+public interface TypeConsumerValidator<T, ValidationResult, ViewModel> {
+
+    /**
+     * Performs this operation on the given arguments.
+     * @param t
+     * @param validationResult
+     * @param viewModel
+     */
+    void accept(T t, ValidationResult validationResult, ViewModel viewModel);
+
+    default TypeConsumerValidator<T, ValidationResult, ViewModel> andThen(TypeConsumerValidator<? super T, ValidationResult, ViewModel> after) {
+        Objects.requireNonNull(after);
+        return (l, r, x) -> {
+            accept(l, r, x);
+            after.accept(l, r, x);
+        };
+    }
+}

--- a/src/main/java/org/carlfx/cognitive/validator/ValidationMessage.java
+++ b/src/main/java/org/carlfx/cognitive/validator/ValidationMessage.java
@@ -19,11 +19,8 @@
 package org.carlfx.cognitive.validator;
 
 
-
 import org.carlfx.cognitive.viewmodel.Validatable;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -85,13 +82,11 @@ public record ValidationMessage(String propertyName, MessageType messageType, in
      */
     public String interpolate(Validatable vvmodel) {
         Matcher matcher = PROPERTY_PATTERN.matcher(this.message);
-        List<String> props = new ArrayList<>();
         String newMessage = this.message;
         while (matcher.find()) {
             String subPropName = matcher.group();
             String propName = matcher.group(1);
-            props.add(matcher.group());
-            String friendlyName =vvmodel.getFriendlyName(propName);
+            String friendlyName = vvmodel.getFriendlyName(propName);
             if (friendlyName != null) {
                 newMessage = newMessage.replace(subPropName, friendlyName);
             }

--- a/src/main/java/org/carlfx/cognitive/validator/ValidationResult.java
+++ b/src/main/java/org/carlfx/cognitive/validator/ValidationResult.java
@@ -1,0 +1,252 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright © 2024. Carl Dea.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.carlfx.cognitive.validator;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Collects validation messages for one property name.
+ */
+public class ValidationResult {
+    private List<ValidationMessage> messages = new ArrayList<>();
+
+    private final String propertyName;
+
+    /**
+     * Constructor
+     * @param propertyName Property name or field.
+     */
+    public ValidationResult(String propertyName) {
+        this.propertyName = propertyName;
+    }
+
+    /**
+     * Adds an error validation message.
+     * @param propertyName Property name
+     * @param message Message when validation evaluates to invalid.
+     * @param errorCode -1 for unknown otherwise a specific error number.
+     * @param throwable A thrown exception.
+     */
+    public void error(String propertyName, String message, int errorCode, Throwable throwable) {
+        messages.add(new ValidationMessage(propertyName, MessageType.ERROR, errorCode, message, throwable));
+    }
+    /**
+     * Adds an error validation message.
+     * @param message Message when validation evaluates to invalid.
+     * @param errorCode -1 for unknown otherwise a specific error number.
+     * @param throwable A thrown exception.
+     */
+    public void error(String message, int errorCode, Throwable throwable) {
+        this.error(propertyName, message, errorCode, throwable);
+    }
+    /**
+     * Adds an error validation message.
+     * @param propertyName Property name
+     * @param message Message when validation evaluates to invalid.
+     * @param throwable A thrown exception.
+     */
+    public void error(String propertyName, String message, Throwable throwable) {
+        messages.add(new ValidationMessage(propertyName, MessageType.ERROR, -1, message, throwable));
+    }
+    /**
+     * Adds an error validation message.
+     * @param message Message when validation evaluates to invalid.
+     * @param throwable A thrown exception.
+     */
+    public void error(String message, Throwable throwable) {
+        this.error(propertyName, message, throwable);
+    }
+    /**
+     * Adds an error validation message.
+     * @param propertyName Property name
+     * @param message Message when validation evaluates to invalid.
+     * @param errorCode -1 for unknown otherwise a specific error number.
+     */
+    public void error(String propertyName, String message, int errorCode) {
+        messages.add(new ValidationMessage(propertyName, MessageType.ERROR, errorCode, message));
+    }
+    /**
+     * Adds an error validation message.
+     * @param message Message when validation evaluates to invalid.
+     * @param errorCode -1 for unknown otherwise a specific error number.
+     */
+    public void error(String message, int errorCode) {
+        this.error(propertyName, message, errorCode);
+    }
+    /**
+     * Adds an error validation message.
+     * @param propertyName Property name
+     * @param message Message when validation evaluates to invalid.
+     */
+    public void error(String propertyName, String message) {
+        messages.add(new ValidationMessage(propertyName, MessageType.ERROR, message));
+    }
+    /**
+     * Adds an error validation message.
+     * @param message Message when validation evaluates to invalid.
+     */
+    public void error(String message) {
+        this.error(propertyName, message);
+    }
+
+    /**
+     * Adds a warning validation message.
+     * @param propertyName Property name
+     * @param message Message when validation evaluates to invalid.
+     * @param errorCode -1 for unknown otherwise a specific error number.
+     * @param throwable A thrown exception.
+     */
+    public void warn(String propertyName, String message, int errorCode, Throwable throwable) {
+        messages.add(new ValidationMessage(propertyName, MessageType.WARN, errorCode, message, throwable));
+    }
+    /**
+     * Adds a warning validation message.
+     * @param message Message when validation evaluates to invalid.
+     * @param errorCode -1 for unknown otherwise a specific error number.
+     * @param throwable A thrown exception.
+     */
+    public void warn(String message, int errorCode, Throwable throwable) {
+        this.warn(propertyName, message, errorCode, throwable);
+    }
+
+    /**
+     * Adds a warning validation message.
+     * @param message Message when validation evaluates to invalid.
+     * @param throwable A thrown exception.
+     */
+    public void warn(String propertyName, String message, Throwable throwable) {
+        messages.add(new ValidationMessage(propertyName, MessageType.WARN, -1, message, throwable));
+    }
+    /**
+     * Adds a warning validation message.
+     * @param message Message when validation evaluates to invalid.
+     * @param throwable A thrown exception.
+     */
+    public void warn(String message, Throwable throwable) {
+        this.warn(propertyName, message, throwable);
+    }
+    /**
+     * Adds a warning validation message.
+     * @param message Message when validation evaluates to invalid.
+     * @param errorCode -1 for unknown otherwise a specific error number.
+     */
+    public void warn(String propertyName, String message, int errorCode) {
+        messages.add(new ValidationMessage(propertyName, MessageType.WARN, errorCode, message));
+    }
+    /**
+     * Adds a warning validation message.
+     * @param message Message when validation evaluates to invalid.
+     * @param errorCode -1 for unknown otherwise a specific error number.
+     */
+    public void warn(String message, int errorCode) {
+        this.warn(propertyName, message, errorCode);
+    }
+    /**
+     * Adds a warning validation message.
+     * @param message Message when validation evaluates to invalid.
+     */
+    public void warn(String propertyName, String message) {
+        messages.add(new ValidationMessage(propertyName, MessageType.WARN, message));
+    }
+    /**
+     * Adds a warning validation message.
+     * @param message Message when validation evaluates to invalid.
+     */
+    public void warn(String message) {
+        this.warn(propertyName, message);
+    }
+
+    /**
+     * Adds an information validation message.
+     * @param propertyName Property name
+     * @param message Message when validation evaluates to invalid.
+     * @param errorCode -1 for unknown otherwise a specific error number.
+     * @param throwable A thrown exception.
+     */
+    public void info(String propertyName, String message, int errorCode, Throwable throwable) {
+        messages.add(new ValidationMessage(propertyName, MessageType.INFO, errorCode, message, throwable));
+    }
+    /**
+     * Adds an information validation message.
+     * @param message Message when validation evaluates to invalid.
+     * @param errorCode -1 for unknown otherwise a specific error number.
+     * @param throwable A thrown exception.
+     */
+    public void info(String message, int errorCode, Throwable throwable) {
+        this.info(propertyName, message, errorCode, throwable);
+    }
+    /**
+     * Adds an information validation message.
+     * @param propertyName Property name
+     * @param message Message when validation evaluates to invalid.
+     * @param throwable A thrown exception.
+     */
+    public void info(String propertyName, String message, Throwable throwable) {
+        messages.add(new ValidationMessage(propertyName, MessageType.INFO, -1, message, throwable));
+    }
+    /**
+     * Adds an information validation message.
+     * @param message Message when validation evaluates to invalid.
+     * @param throwable A thrown exception.
+     */
+    public void info(String message, Throwable throwable) {
+        this.info(propertyName, message, throwable);
+    }
+    /**
+     * Adds an information validation message.
+     * @param propertyName Property name
+     * @param message Message when validation evaluates to invalid.
+     * @param errorCode -1 for unknown otherwise a specific error number.
+     */
+    public void info(String propertyName, String message, int errorCode) {
+        messages.add(new ValidationMessage(propertyName, MessageType.INFO, errorCode, message));
+    }
+    /**
+     * Adds an information validation message.
+     * @param message Message when validation evaluates to invalid.
+     * @param errorCode -1 for unknown otherwise a specific error number.
+     */
+    public void info(String message, int errorCode) {
+        this.info(propertyName, message, errorCode);
+    }
+    /**
+     * Adds an information validation message.
+     * @param propertyName Property name
+     * @param message Message when validation evaluates to invalid.
+     */
+    public void info(String propertyName, String message) {
+        messages.add(new ValidationMessage(propertyName, MessageType.INFO, message));
+    }
+    /**
+     * Adds an information validation message.
+     * @param message Message when validation evaluates to invalid.
+     */
+    public void info(String message) {
+        this.info(propertyName, message);
+    }
+
+    /**
+     * Returns a list of ValidationMessage objects.
+     * @return Returns a list of ValidationMessage objects.
+     */
+    public List<ValidationMessage> getMessages(){
+        return messages;
+    }
+}

--- a/src/main/java/org/carlfx/cognitive/viewmodel/IdValidationViewModel.java
+++ b/src/main/java/org/carlfx/cognitive/viewmodel/IdValidationViewModel.java
@@ -319,6 +319,15 @@ import java.util.stream.Collectors;
         return this;
     }
 
+    public IdValidationViewModel addValidator(Object name, String friendlyName, ObjectConsumerValidator validator) {
+        ifPresentOrElse(name,
+                propertyIdentifier -> Validatable.super.addValidator(propertyIdentifier.idToString(), friendlyName, validator),
+                propName -> Validatable.super.addValidator(propName, friendlyName, validator)
+        );
+        return this;
+    }
+
+
     @Override
     public IdValidationViewModel addValidator(String name, String friendlyName, IntegerValidator validator) {
         return this.addValidator((Object) name, friendlyName, validator);
@@ -488,6 +497,56 @@ import java.util.stream.Collectors;
     }
 
     @Override
+    public IdValidationViewModel addValidator(String name, String friendlyName, BooleanConsumerValidator validator) {
+        return Validatable.super.addValidator(name, friendlyName, validator);
+    }
+
+    @Override
+    public IdValidationViewModel addValidator(String name, String friendlyName, DoubleConsumerValidator validator) {
+        return Validatable.super.addValidator(name, friendlyName, validator);
+    }
+
+    @Override
+    public IdValidationViewModel addValidator(String name, String friendlyName, FloatConsumerValidator validator) {
+        return Validatable.super.addValidator(name, friendlyName, validator);
+    }
+
+    @Override
+    public IdValidationViewModel addValidator(String name, String friendlyName, IntegerConsumerValidator validator) {
+        return Validatable.super.addValidator(name, friendlyName, validator);
+    }
+
+    @Override
+    public IdValidationViewModel addValidator(String name, String friendlyName, ListConsumerValidator validator) {
+        return Validatable.super.addValidator(name, friendlyName, validator);
+    }
+
+    @Override
+    public IdValidationViewModel addValidator(String name, String friendlyName, LongConsumerValidator validator) {
+        return Validatable.super.addValidator(name, friendlyName, validator);
+    }
+
+    @Override
+    public IdValidationViewModel addValidator(String name, String friendlyName, ObjectConsumerValidator validator) {
+        return Validatable.super.addValidator(name, friendlyName, validator);
+    }
+
+    @Override
+    public IdValidationViewModel addValidator(String name, String friendlyName, SetConsumerValidator validator) {
+        return Validatable.super.addValidator(name, friendlyName, validator);
+    }
+
+    @Override
+    public IdValidationViewModel addValidator(String name, String friendlyName, StringConsumerValidator validator) {
+        return Validatable.super.addValidator(name, friendlyName, validator);
+    }
+
+    @Override
+    public IdValidationViewModel addValidator(String name, String friendlyName, ConsumerValidator validator) {
+        return Validatable.super.addValidator(name, friendlyName, validator);
+    }
+
+    @Override
     public IdValidationViewModel validate() {
         validationManager.validate(this);
         return this;
@@ -543,7 +602,10 @@ import java.util.stream.Collectors;
     public String getFriendlyName(Object propertName) {
         Optional<PropertyIdentifier> propertyIdentifier = findPropertyIdentifierByKey(propertName);
         if (propertyIdentifier.isPresent()) {
-            return Validatable.super.getFriendlyName(propertyIdentifier.get().idToString());
+            String found = Validatable.super.getFriendlyName(propertyIdentifier.get().idToString());
+            if (found != null) {
+                return found;
+            }
         }
         return Validatable.super.getFriendlyName(String.valueOf(propertName));
     }

--- a/src/main/java/org/carlfx/cognitive/viewmodel/Validatable.java
+++ b/src/main/java/org/carlfx/cognitive/viewmodel/Validatable.java
@@ -17,6 +17,7 @@
  */
 package org.carlfx.cognitive.viewmodel;
 
+import javafx.beans.property.*;
 import org.carlfx.cognitive.validator.*;
 
 import java.util.List;
@@ -141,6 +142,176 @@ public interface Validatable {
     <U extends ViewModel> U addValidator(String name, String friendlyName, CustomValidator validator);
 
     /**
+     * A consumer validator creates a validator that allows the code to eval validation logic and can generate multiple error messages.
+     * This consumer validator is converted to an actual typed Validator.
+     * As a convenience the boolean property is passed in to be used.
+     * @param name Property name
+     * @param friendlyName Friendly name of property name
+     * @param validator consumer validator converts to an actual type validator.
+     *                  e.g. BooleanValidator (ReadOnlyBooleanProperty prop, ViewModel vm) -> accumulateMessagesFunction(name, validator, prop);
+     * @return returns itself following the builder pattern.
+     * @param <U> U is a derived class of type ViewModel.
+     */
+    default <U extends ViewModel> U addValidator(String name, String friendlyName, BooleanConsumerValidator validator){
+        BooleanValidator tValidator = (ReadOnlyBooleanProperty prop, ViewModel vm) -> accumulateMessagesFunction(name, validator, prop);
+        getValidationManager().createFieldValidator(name, friendlyName, tValidator);
+        return (U) this;
+    }
+
+    /**
+     * A consumer validator creates a validator that allows the code to eval validation logic and can generate multiple error messages.
+     * This consumer validator is converted to an actual typed Validator.
+     * As a convenience the double property is passed in to be used.
+     * @param name Property name
+     * @param friendlyName Friendly name of property name
+     * @param validator consumer validator converts to an actual type validator.
+     *                  e.g. BooleanValidator (ReadOnlyBooleanProperty prop, ViewModel vm) -> accumulateMessagesFunction(name, validator, prop);
+     * @return returns itself following the builder pattern.
+     * @param <U> U is a derived class of type ViewModel.
+     */
+    default <U extends ViewModel> U addValidator(String name, String friendlyName, DoubleConsumerValidator validator){
+        DoubleValidator tValidator = (ReadOnlyDoubleProperty prop, ViewModel vm) -> accumulateMessagesFunction(name, validator, prop);
+        getValidationManager().createFieldValidator(name, friendlyName, tValidator);
+        return (U) this;
+    }
+
+    /**
+     * A consumer validator creates a validator that allows the code to eval validation logic and can generate multiple error messages.
+     * This consumer validator is converted to an actual typed Validator.
+     * As a convenience the float property is passed in to be used.
+     * @param name Property name
+     * @param friendlyName Friendly name of property name
+     * @param validator consumer validator converts to an actual type validator.
+     *                  e.g. BooleanValidator (ReadOnlyBooleanProperty prop, ViewModel vm) -> accumulateMessagesFunction(name, validator, prop);
+     * @return returns itself following the builder pattern.
+     * @param <U> U is a derived class of type ViewModel.
+     */
+    default <U extends ViewModel> U addValidator(String name, String friendlyName, FloatConsumerValidator validator){
+        FloatValidator tValidator = (ReadOnlyFloatProperty prop, ViewModel vm) -> accumulateMessagesFunction(name, validator, prop);
+        getValidationManager().createFieldValidator(name, friendlyName, tValidator);
+        return (U) this;
+    }
+
+    /**
+     * A consumer validator creates a validator that allows the code to eval validation logic and can generate multiple error messages.
+     * This consumer validator is converted to an actual typed Validator.
+     * As a convenience the integer property is passed in to be used.
+     * @param name Property name
+     * @param friendlyName Friendly name of property name
+     * @param validator consumer validator converts to an actual type validator.
+     *                  e.g. BooleanValidator (ReadOnlyBooleanProperty prop, ViewModel vm) -> accumulateMessagesFunction(name, validator, prop);
+     * @return returns itself following the builder pattern.
+     * @param <U> U is a derived class of type ViewModel.
+     */
+    default <U extends ViewModel> U addValidator(String name, String friendlyName, IntegerConsumerValidator validator){
+        IntegerValidator tValidator = (ReadOnlyIntegerProperty prop, ViewModel vm) -> accumulateMessagesFunction(name, validator, prop);
+        getValidationManager().createFieldValidator(name, friendlyName, tValidator);
+        return (U) this;
+    }
+
+    /**
+     * A consumer validator creates a validator that allows the code to eval validation logic and can generate multiple error messages.
+     * This consumer validator is converted to an actual typed Validator.
+     * As a convenience the list as a read-only property is passed in to be used.
+     * @param name Property name
+     * @param friendlyName Friendly name of property name
+     * @param validator consumer validator converts to an actual type validator.
+     *                  e.g. BooleanValidator (ReadOnlyBooleanProperty prop, ViewModel vm) -> accumulateMessagesFunction(name, validator, prop);
+     * @return returns itself following the builder pattern.
+     * @param <U> U is a derived class of type ViewModel.
+     */
+    default <U extends ViewModel> U addValidator(String name, String friendlyName, ListConsumerValidator validator){
+        ListValidator tValidator = (ReadOnlyListProperty prop, ViewModel vm) -> accumulateMessagesFunction(name, validator, prop);
+        getValidationManager().createFieldValidator(name, friendlyName, tValidator);
+        return (U) this;
+    }
+
+    /**
+     * A consumer validator creates a validator that allows the code to eval validation logic and can generate multiple error messages.
+     * This consumer validator is converted to an actual typed Validator.
+     * As a convenience the Long as a read-only property is passed in to be used.
+     * @param name Property name
+     * @param friendlyName Friendly name of property name
+     * @param validator consumer validator converts to an actual type validator.
+     *                  e.g. BooleanValidator (ReadOnlyBooleanProperty prop, ViewModel vm) -> accumulateMessagesFunction(name, validator, prop);
+     * @return returns itself following the builder pattern.
+     * @param <U> U is a derived class of type ViewModel.
+     */
+    default <U extends ViewModel> U addValidator(String name, String friendlyName, LongConsumerValidator validator){
+        LongValidator tValidator = (ReadOnlyLongProperty prop, ViewModel vm) -> accumulateMessagesFunction(name, validator, prop);
+        getValidationManager().createFieldValidator(name, friendlyName, tValidator);
+        return (U) this;
+    }
+
+    /**
+     * A consumer validator creates a validator that allows the code to eval validation logic and can generate multiple error messages.
+     * This consumer validator is converted to an actual typed Validator.
+     * As a convenience the object as a read-only property is passed in to be used.
+     * @param name Property name
+     * @param friendlyName Friendly name of property name
+     * @param validator consumer validator converts to an actual type validator.
+     *                  e.g. BooleanValidator (ReadOnlyBooleanProperty prop, ViewModel vm) -> accumulateMessagesFunction(name, validator, prop);
+     * @return returns itself following the builder pattern.
+     * @param <U> U is a derived class of type ViewModel.
+     */
+    default <U extends ViewModel> U addValidator(String name, String friendlyName, ObjectConsumerValidator validator){
+        ObjectValidator tValidator = (ReadOnlyObjectProperty prop, ViewModel vm) -> accumulateMessagesFunction(name, validator, prop);
+        getValidationManager().createFieldValidator(name, friendlyName, tValidator);
+        return (U) this;
+    }
+
+    /**
+     * A consumer validator creates a validator that allows the code to eval validation logic and can generate multiple error messages.
+     * This consumer validator is converted to an actual typed Validator.
+     * As a convenience the set as a read-only property is passed in to be used.
+     * @param name Property name
+     * @param friendlyName Friendly name of property name
+     * @param validator consumer validator converts to an actual type validator.
+     *                  e.g. BooleanValidator (ReadOnlyBooleanProperty prop, ViewModel vm) -> accumulateMessagesFunction(name, validator, prop);
+     * @return returns itself following the builder pattern.
+     * @param <U> U is a derived class of type ViewModel.
+     */
+    default <U extends ViewModel> U addValidator(String name, String friendlyName, SetConsumerValidator validator){
+        SetValidator tValidator = (ReadOnlySetProperty prop, ViewModel vm) -> accumulateMessagesFunction(name, validator, prop);
+        getValidationManager().createFieldValidator(name, friendlyName, tValidator);
+        return (U) this;
+    }
+
+    /**
+     * A consumer validator creates a validator that allows the code to eval validation logic and can generate multiple error messages.
+     * This consumer validator is converted to an actual typed Validator.
+     * As a convenience the string as a read-only property is passed in to be used.
+     * @param name Property name
+     * @param friendlyName Friendly name of property name
+     * @param validator consumer validator converts to an actual type validator.
+     *                  e.g. BooleanValidator (ReadOnlyBooleanProperty prop, ViewModel vm) -> accumulateMessagesFunction(name, validator, prop);
+     * @return returns itself following the builder pattern.
+     * @param <U> U is a derived class of type ViewModel.
+     */
+    default <U extends ViewModel> U addValidator(String name, String friendlyName, StringConsumerValidator validator){
+        StringValidator stringValidator = (ReadOnlyStringProperty prop, ViewModel vm) -> accumulateMessagesFunction(name, validator, prop);
+        getValidationManager().createFieldValidator(name, friendlyName, stringValidator);
+        return (U) this;
+    }
+
+    /**
+     * A consumer validator creates a validator that allows the code to eval validation logic and can generate multiple error messages.
+     * This consumer validator is converted to an actual custom validator.
+     *
+     * @param name Property name
+     * @param friendlyName Friendly name of property name
+     * @param validator consumer validator converts to an actual type validator.
+     *                  e.g. CustomValidator customValidator = (Void prop, ViewModel vm) -> accumulateMessagesFunction(name, validator);
+     * @return returns itself following the builder pattern.
+     * @param <U> U is a derived class of type ViewModel.
+     */
+    default <U extends ViewModel> U addValidator(String name, String friendlyName, ConsumerValidator validator){
+        CustomValidator customValidator = (Void prop, ViewModel vm) -> accumulateMessagesFunction(name, validator);
+        getValidationManager().createFieldValidator(name, friendlyName, customValidator);
+        return (U) this;
+    }
+
+    /**
      * Goes through all validators to execute creating error, warning, info
      * @return Returns a ViewModel following the builder pattern.
      * @param <U> U is a view model of type ViewModel
@@ -229,4 +400,36 @@ public interface Validatable {
         return getValidationManager().getFriendlyName(propertName);
     }
 
+    /**
+     * Based on the property name, consumer validator will pass caller an empty validation result (no messages).
+     * @param name Property name
+     * @param validator Consumer validator allows caller to add messages to validation result object.
+     * @param prop the property as a read-only
+     * @return ValidationMessage will be null or VALID. Messages will be in validation result.
+     */
+    default ValidationMessage accumulateMessagesFunction(String name, TypeConsumerValidator validator, ReadOnlyProperty prop) {
+        ValidationResult inputValidationResult = new ValidationResult(name);
+        // accumulate error messages
+        validator.accept(prop, inputValidationResult, this);
+        getValidationManager()
+                .getValidationMessages()
+                .addAll(inputValidationResult.getMessages());
+        return VALID;
+    }
+
+    /**
+     * Based on the property name, consumer validator will pass caller an empty validation result (no messages).
+     * @param name Property name
+     * @param validator Consumer validator allows caller to add messages to validation result object.
+     * @return ValidationMessage will be null or VALID. Messages will be in validation result.
+     */
+    default ValidationMessage accumulateMessagesFunction(String name, ConsumerValidator validator) {
+        ValidationResult inputValidationResult = new ValidationResult(name);
+        // accumulate error messages
+        validator.accept(inputValidationResult, (ViewModel) this);
+        getValidationManager()
+                .getValidationMessages()
+                .addAll(inputValidationResult.getMessages());
+        return VALID;
+    }
 }

--- a/src/main/java/org/carlfx/cognitive/viewmodel/ValidationViewModel.java
+++ b/src/main/java/org/carlfx/cognitive/viewmodel/ValidationViewModel.java
@@ -21,7 +21,9 @@ package org.carlfx.cognitive.viewmodel;
 import javafx.beans.property.Property;
 import org.carlfx.cognitive.validator.*;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 import java.util.stream.Collectors;
 
 /**
@@ -323,8 +325,58 @@ public class ValidationViewModel extends SimpleViewModel implements Validatable 
      *
      */
     public ValidationViewModel addValidator(String name, String friendlyName, CustomValidator validator) {
-        validationManager.createFieldValidator(name, friendlyName, validator);
+        getValidationManager().createFieldValidator(name, friendlyName, validator);
         return this;
+    }
+
+    @Override
+    public ValidationViewModel addValidator(String name, String friendlyName, BooleanConsumerValidator validator) {
+        return Validatable.super.addValidator(name, friendlyName, validator);
+    }
+
+    @Override
+    public ValidationViewModel addValidator(String name, String friendlyName, DoubleConsumerValidator validator) {
+        return Validatable.super.addValidator(name, friendlyName, validator);
+    }
+
+    @Override
+    public ValidationViewModel addValidator(String name, String friendlyName, FloatConsumerValidator validator) {
+        return Validatable.super.addValidator(name, friendlyName, validator);
+    }
+
+    @Override
+    public ValidationViewModel addValidator(String name, String friendlyName, IntegerConsumerValidator validator) {
+        return Validatable.super.addValidator(name, friendlyName, validator);
+    }
+
+    @Override
+    public ValidationViewModel addValidator(String name, String friendlyName, ListConsumerValidator validator) {
+        return Validatable.super.addValidator(name, friendlyName, validator);
+    }
+
+    @Override
+    public ValidationViewModel addValidator(String name, String friendlyName, LongConsumerValidator validator) {
+        return Validatable.super.addValidator(name, friendlyName, validator);
+    }
+
+    @Override
+    public ValidationViewModel addValidator(String name, String friendlyName, ObjectConsumerValidator validator) {
+        return Validatable.super.addValidator(name, friendlyName, validator);
+    }
+
+    @Override
+    public ValidationViewModel addValidator(String name, String friendlyName, SetConsumerValidator validator) {
+        return Validatable.super.addValidator(name, friendlyName, validator);
+    }
+
+    @Override
+    public ValidationViewModel addValidator(String name, String friendlyName, StringConsumerValidator validator) {
+        return Validatable.super.addValidator(name, friendlyName, validator);
+    }
+
+    @Override
+    public ValidationViewModel addValidator(String name, String friendlyName, ConsumerValidator validator) {
+        return Validatable.super.addValidator(name, friendlyName, validator);
     }
 
     /**

--- a/src/test/java/org/carlfx/cognitive/test/demo/AccountCreateController.java
+++ b/src/test/java/org/carlfx/cognitive/test/demo/AccountCreateController.java
@@ -94,27 +94,21 @@ public class AccountCreateController {
         transactionMessageText.textProperty().bindBidirectional(accountViewModel.getProperty(TRANSACTION_TEXT));
     }
     private void clearForm() {
+        // TODO accountViewModel.reset()
+        accountViewModel.setPropertyValue(FIRST_NAME, "");
+        accountViewModel.setPropertyValue(LAST_NAME, "");
+        accountViewModel.setPropertyValue(EMAIL, "");
+        accountViewModel.setPropertyValue(TRANSACTION_TEXT, "");
+
+        // TODO refactor to use view model instead
         emailOverlay.setVisible(false);
-
-        emailTF.setText("");
-
         emailTooltip.setText("");
-
         firstNameErrorOverlay.setVisible(false);
-
-        firstNameTF.setText("");
-
         firstNameTooltip.setText("");
-
         lastNameErrorOverlay.setVisible(false);
-
-        lastNameTF.setText("");
-
         lastNameTooltip.setText("");
-
         submitButton.setDisable(true);
 
-        transactionMessageText.setText("");
 
     }
     private void resetErrorOverlays() {

--- a/src/test/java/org/carlfx/cognitive/test/demo/AccountViewModel.java
+++ b/src/test/java/org/carlfx/cognitive/test/demo/AccountViewModel.java
@@ -20,6 +20,7 @@ package org.carlfx.cognitive.test.demo;
 import javafx.beans.property.ReadOnlyStringProperty;
 import org.carlfx.cognitive.validator.MessageType;
 import org.carlfx.cognitive.validator.ValidationMessage;
+import org.carlfx.cognitive.validator.ValidationResult;
 import org.carlfx.cognitive.viewmodel.ValidationViewModel;
 import org.carlfx.cognitive.viewmodel.ViewModel;
 
@@ -49,11 +50,14 @@ public class AccountViewModel extends ValidationViewModel {
                     }
                     return VALID;
                 })
-                .addValidator(FIRST_NAME, "First Name", (ReadOnlyStringProperty prop, ViewModel vm) -> {
+                .addValidator(FIRST_NAME, "First Name", (ReadOnlyStringProperty prop, ValidationResult validationResult, ViewModel viewModel) -> {
                     if (prop.isEmpty().get() || prop.isNotEmpty().get() && prop.get().length() < 3) {
-                        return new ValidationMessage(FIRST_NAME, MessageType.ERROR, "${%s} must be greater than 3 characters.".formatted(FIRST_NAME));
+                        validationResult.error(FIRST_NAME, "${%s} must be greater than 3 characters.".formatted(FIRST_NAME));
                     }
-                    return VALID;
+                    String firstChar = String.valueOf(prop.get().charAt(0));
+                    if (firstChar.equals(firstChar.toLowerCase())) {
+                        validationResult.error(FIRST_NAME, "${%s} first character must be upper case.".formatted(FIRST_NAME));
+                    }
                 });
 
         addProperty(LAST_NAME, "")


### PR DESCRIPTION
Validators currently only support one return of a validation message. This feature will allow you to add multiple error/warn/info messages when validating a property or custom property.

Please see feature issue https://github.com/carldea/cognitive/issues/6

Added some tests, examples, and updated demo for first name field.